### PR TITLE
Add baseurl so dev environment urls don't break

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 title: "Servo Blog"
 description: ""
 url: "http://blog.servo.org"
+baseurl: "http://servo.github.io/blog.servo.org"
 google_analytics: 
 
 #  Build settings


### PR DESCRIPTION
Addresses #45 
This worked for me: see example at http://lucywyman.me/blog.servo.org/

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/blog.servo.org/47)

<!-- Reviewable:end -->
