### PR TITLE
The redirect is no more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # blog.servo.org
 
-This is the servo blog, to which [servo.org](https://github.com/servo/servo.org)
-currently redirects. 
+This is code for the servo blog: http://blog.servo.org
 
 # Contributing
 


### PR DESCRIPTION
...so we shouldn't refer to it any more.

(Btw, what is the license for this repo? It seems to be missing a clear license.)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/blog.servo.org/78)

<!-- Reviewable:end -->
