### PR TITLE
Use HTTPS link to nightlies download page

### DIFF
--- a/_posts/2016-06-30-servo-nightlies.md
+++ b/_posts/2016-06-30-servo-nightlies.md
@@ -14,7 +14,7 @@ have created packages for macOS and Linux; Windows and Android packages should
 be available soon.
 
 Binary packages and installation instructions are available at
-[download.servo.org](http://download.servo.org/index.html).
+[https://servo-builds.s3.amazonaws.com/index.html](https://servo-builds.s3.amazonaws.com/index.html).
 
 When you first run Servo, you see a new tab page containing a selection of
 sites that Servo renders well and some tech demos. A


### PR DESCRIPTION
This is temporary until the dl.servo.org and download.servo.org
redirects point to HTTPS pages.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/blog.servo.org/96)

<!-- Reviewable:end -->
