### PR TITLE
Switch to https-enabled download.servo.org

### DIFF
--- a/_posts/2016-06-30-servo-nightlies.md
+++ b/_posts/2016-06-30-servo-nightlies.md
@@ -14,7 +14,7 @@ have created packages for macOS and Linux (64-bit); Windows and Android packages
 be available soon.
 
 Binary packages and installation instructions are available at
-[https://servo-builds.s3.amazonaws.com/index.html](https://servo-builds.s3.amazonaws.com/index.html).
+[https://download.servo.org/](https://download.servo.org/).
 
 When you first run Servo, you see a new tab page containing a selection of
 sites that Servo renders well and some tech demos. A


### PR DESCRIPTION
HTTPS has now been enabled for the site,
and it automatically shows the index page.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/blog.servo.org/98)

<!-- Reviewable:end -->
