### PR TITLE
Use jekyll-seo-tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,4 @@ paginate: 10
 
 gems:
   - jekyll-redirect-from
+  - jekyll-seo-tag

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,11 +1,8 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+    {% seo %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="{{ site.description }}">
-    <meta name="author" content="{{ site.author }}">
-    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl }}">
     <link rel="alternate" type="application/atom+xml" title="Atom feed" href="{{ "/feed.xml" | prepend: site.baseurl }}">
 
     <!-- Custom CSS -->


### PR DESCRIPTION
This gem does [a number of things](https://github.com/jekyll/jekyll-seo-tag) but the one I'm interested is adding next/previous meta tags to paginated pages, which my browser has keyboard shortcuts for easily navigating through a site with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/blog.servo.org/128)
<!-- Reviewable:end -->
