### PR TITLE
Fix typo on 石博文's GitHub URL address

### DIFF
--- a/_posts/2017-04-24-twis-99.md
+++ b/_posts/2017-04-24-twis-99.md
@@ -45,7 +45,7 @@ This week's status updates are [here](https://www.standu.ps/project/servo/).
 - [alfredoyang](https://github.com/)
 - [coalman](https://github.com/coalman)
 - [cu1t](https://github.com/cu1t)
-- [石博文](https://github.com/spwtw)
+- [石博文](https://github.com/sbwtw)
 - [Bruce Mitchener](https://github.com/waywardmonkeys)
 
 Interested in helping build a web browser? Take a look at our [curated list](https://starters.servo.org/) of issues that are good for new contributors!


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/blog.servo.org/147)
<!-- Reviewable:end -->
