### PR TITLE
Fix user's GitHub URL

### DIFF
--- a/_posts/2017-04-24-twis-99.md
+++ b/_posts/2017-04-24-twis-99.md
@@ -42,7 +42,7 @@ This week's status updates are [here](https://www.standu.ps/project/servo/).
 ### New Contributors
 
 - [Alex Touchet](https://github.com/atouchet)
-- [alfredoyang](https://github.com/)
+- [alfredoyang](https://github.com/alfredoyang)
 - [coalman](https://github.com/coalman)
 - [cu1t](https://github.com/cu1t)
 - [石博文](https://github.com/sbwtw)


### PR DESCRIPTION
I'm assuming this wasn't supposed to direct to the GitHub homepage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/blog.servo.org/148)
<!-- Reviewable:end -->
