### PR TITLE
Minor fix. s/video/HTMLVideoElement/

### DIFF
--- a/_posts/2018-09-10-twis-113.md
+++ b/_posts/2018-09-10-twis-113.md
@@ -19,7 +19,7 @@ This week's status updates are [here](https://www.standu.ps/project/servo/).
 
 - eijebong is [updating hyper](https://github.com/servo/servo/pull/21644) from 0.10 to 0.12, enabling Servo to make use of async I/O in the future
 - kingdido999, chansuke, pyfisch, and AnshulMalik are [running rustfmt](https://github.com/servo/servo/issues/21373) on all 100k+ lines of code in Servo
-- ceyusa is [implementing support for <video>](https://github.com/servo/servo/pull/21543) based on GStreamer
+- ceyusa is [implementing support for HTMLVideoElement](https://github.com/servo/servo/pull/21543) based on GStreamer
 - retep007 is [splitting the massive script crate](https://github.com/servo/servo/pull/21371) into smaller crates
 - ferjm is [enabling GStreamer support](https://github.com/servo/servo/pull/21730) on Android
 


### PR DESCRIPTION
Using `<video>` breaks the layout.

![screenshot_2018-09-18 these months in servo 112](https://user-images.githubusercontent.com/480202/45691674-55c11200-bb59-11e8-846d-6b0a0b0dcbc8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/blog.servo.org/166)
<!-- Reviewable:end -->
