### PR TITLE
Fix broken link

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,3 +1,3 @@
 <a href="https://servo.org/">Home</a>
-<!--<a href="https://servo.org/starters">Contributing</a>-->
+<a href="https://starters.servo.org/">Contributing</a>
 <a href="https://github.com/servo/servo">GitHub</a>


### PR DESCRIPTION
I think servo.org/starters used to redirect to starters.servo.org before
the site redesign.