### PR TITLE
Fix broken link in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <div class="measure mt1 center">
       <small>
         Theme by <a href="http://johnotander.com">John Otander</a>.<br>
-        &lt;/&gt; available on <a href="https://github.com/johnotander/pixyll.git">Github</a>.
+        &lt;/&gt; available on <a href="https://github.com/johno/pixyll.git">Github</a>.
       </small>
     </div>
   </div>


### PR DESCRIPTION
pixyll's repo url has been changed to https://github.com/johno/pixyll.